### PR TITLE
docs: explain early repo cloning rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # QRLSAI
+
+## Repository Preparation Clarification
+
+Even if no application code has been committed yet, cloning the repository early is useful because it lets us:
+
+1. Verify our local credentials and access rights to the remote before we start coding.
+2. Establish the exact directory structure and baseline configuration that later steps will build upon.
+3. Track every incremental change with version control so the step-by-step workflow stays consistent.
+
+By setting up the repo first we avoid access surprises later and keep the project history clean once we begin implementing the planned milestones.


### PR DESCRIPTION
## Summary
- document why cloning the repository early is helpful even before coding starts
- outline access verification, structure setup, and change tracking benefits

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d52627f8c0832bb14904731b71c367